### PR TITLE
fix: resolve terminal default colors by value

### DIFF
--- a/src/SvcSystems.UI.Terminal/TerminalControl.cs
+++ b/src/SvcSystems.UI.Terminal/TerminalControl.cs
@@ -1523,7 +1523,7 @@ public partial class TerminalControl : Grid
                         owner._consoleTextSize.Height * row.RowIndex,
                         owner._consoleTextSize.Width * run.CellWidth,
                         owner._consoleTextSize.Height + 1);
-                    context.FillRectangle(owner.ResolveColorBrush(run.BackgroundColor, isForeground: false), runRect);
+                    context.FillRectangle(owner.ResolveColorBrush(run.BackgroundColor), runRect);
 
                     if (owner._canRenderText)
                     {
@@ -1686,8 +1686,8 @@ public partial class TerminalControl : Grid
             (fg, bg) = (bg, fg);
         }
 
-        if (ResolveColorBrush(fg, isForeground: true) is not ISolidColorBrush foregroundBrush ||
-            ResolveColorBrush(bg, isForeground: false) is not ISolidColorBrush backgroundBrush)
+        if (ResolveColorBrush(fg) is not ISolidColorBrush foregroundBrush ||
+            ResolveColorBrush(bg) is not ISolidColorBrush backgroundBrush)
         {
             return false;
         }
@@ -1729,11 +1729,16 @@ public partial class TerminalControl : Grid
         return FallbackXtermPalette[xtermColor];
     }
 
-    private Brush ResolveColorBrush(int color, bool isForeground)
+    private Brush ResolveColorBrush(int color)
     {
-        if (color == 256 || color == 257)
+        if (color == 256)
         {
-            return ResolvePaletteBrush(isForeground ? 15 : 0);
+            return ResolvePaletteBrush(15);
+        }
+
+        if (color == 257)
+        {
+            return ResolvePaletteBrush(0);
         }
 
         if (color is >= 0 and <= 255)
@@ -1763,7 +1768,7 @@ public partial class TerminalControl : Grid
 
         EvictFormattedTextCacheEntriesIfNeeded();
 
-        var foregroundBrush = ResolveColorBrush(run.ForegroundColor, isForeground: true);
+        var foregroundBrush = ResolveColorBrush(run.ForegroundColor);
         var formattedText = new FormattedText(run.Text, CultureInfo.InvariantCulture, FlowDirection.LeftToRight, _typeface, FontSize, foregroundBrush);
         if (run.TextDecorations != null)
         {
@@ -1839,6 +1844,7 @@ public partial class TerminalControl : Grid
     internal int SelectionAutoScrollDeltaForTests => _selectionAutoScrollDelta;
     internal IBrush SelectionBrushForTests => ResolveSelectionBrush();
     internal IBrush ResolveXtermColorForTests(int xtermColor) => ResolvePaletteBrush(xtermColor);
+    internal IBrush ResolveColorForTests(int color) => ResolveColorBrush(color);
 }
 
 internal readonly record struct FormattedTextCacheKey(

--- a/tests/SvcSystems.UI.Terminal.Tests/TerminalControlTests.cs
+++ b/tests/SvcSystems.UI.Terminal.Tests/TerminalControlTests.cs
@@ -256,6 +256,21 @@ public sealed class TerminalControlTests : AvaloniaTestBase
     }
 
     [Fact]
+    public Task TerminalControl_DefaultColorSentinelsResolveByValue()
+    {
+        return RunInHeadlessSession(() =>
+        {
+            var control = CreateControl(out _, out _);
+
+            var defaultForeground = Assert.IsAssignableFrom<Avalonia.Media.ISolidColorBrush>(control.ResolveColorForTests(256));
+            var defaultBackground = Assert.IsAssignableFrom<Avalonia.Media.ISolidColorBrush>(control.ResolveColorForTests(257));
+
+            Assert.Equal(Avalonia.Media.Colors.White, defaultForeground.Color);
+            Assert.Equal(Avalonia.Media.Colors.Black, defaultBackground.Color);
+        });
+    }
+
+    [Fact]
     public Task ResourceStyle_DefaultsAlignFontCaretAndSelection()
     {
         return RunInHeadlessSession(() =>
@@ -311,6 +326,20 @@ public sealed class TerminalControlTests : AvaloniaTestBase
         {
             var control = CreateControl(out var model, out _);
             model.Feed("\u001b[38;2;255;255;255;48;2;255;255;255mA\b");
+
+            var brush = Assert.IsAssignableFrom<Avalonia.Media.ISolidColorBrush>(control.CaretBrushForTests);
+
+            Assert.Equal(Avalonia.Media.Colors.Black, brush.Color);
+        });
+    }
+
+    [Fact]
+    public Task CaretBrush_UsesInverseCellForegroundColor()
+    {
+        return RunInHeadlessSession(() =>
+        {
+            var control = CreateControl(out var model, out _);
+            model.Feed("\u001b[7mA\b");
 
             var brush = Assert.IsAssignableFrom<Avalonia.Media.ISolidColorBrush>(control.CaretBrushForTests);
 

--- a/tests/SvcSystems.UI.Terminal.Tests/TerminalControlTests.cs
+++ b/tests/SvcSystems.UI.Terminal.Tests/TerminalControlTests.cs
@@ -272,6 +272,25 @@ public sealed class TerminalControlTests : AvaloniaTestBase
     }
 
     [Fact]
+    public Task TerminalControl_Render_ResolvesDefaultColorsThroughSurface()
+    {
+        return RunInHeadlessSession(() =>
+        {
+            var control = CreateControl(out var model, out _);
+            model.Feed("A");
+
+            using var bitmap = new Avalonia.Media.Imaging.RenderTargetBitmap(new PixelSize(320, 120));
+            bitmap.Render(control);
+
+            var defaultForeground = Assert.IsAssignableFrom<Avalonia.Media.ISolidColorBrush>(control.ResolveColorForTests(256));
+            var defaultBackground = Assert.IsAssignableFrom<Avalonia.Media.ISolidColorBrush>(control.ResolveColorForTests(257));
+
+            Assert.Equal(Avalonia.Media.Colors.White, defaultForeground.Color);
+            Assert.Equal(Avalonia.Media.Colors.Black, defaultBackground.Color);
+        });
+    }
+
+    [Fact]
     public Task ResourceStyle_DefaultsAlignFontCaretAndSelection()
     {
         return RunInHeadlessSession(() =>


### PR DESCRIPTION
## Summary
- Resolve foreground and background default color sentinels independently.
- Ensure inverse caret rendering uses the correct cell colors.
- Add headless Avalonia regression tests for sentinel colors and inverse caret behavior.

Fixe #69 